### PR TITLE
reconfigure dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,32 +18,6 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
-  - package-ecosystem: "npm"
-    directory: "/packages/app"
-    schedule:
-      interval: "weekly"
-      time: "04:00"
-      timezone: "Asia/Tokyo"
-    versioning-strategy: "lockfile-only"
-    ignore:
-      - dependency-name: "typescript"
-      - dependency-name: "@backstage/*"
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-
-  - package-ecosystem: "npm"
-    directory: "/packages/backend" # Location of package manifests
-    schedule:
-      interval: "weekly"
-      time: "04:00"
-      timezone: "Asia/Tokyo"
-    versioning-strategy: "lockfile-only"
-    ignore:
-      - dependency-name: "typescript"
-      - dependency-name: "@backstage/*"
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major", "version-update:semver-minor"]
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
- only need to specifiy root configuration because it does not contain the lockfile in sub-directories