### PR TITLE
remove useUrlReadersSearch flag

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -100,7 +100,4 @@ catalog:
     #   target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
     #   rules:
     #     - allow: [User, Group]
-  # Experimental: Always use the search method in UrlReaderProcessor.
-  # New adopters are encouraged to enable it as this behavior will be the default in a future release.
-  useUrlReadersSearch: true
   


### PR DESCRIPTION
The experimental catalog.useUrlReadersSearch configuration flag (introduced in v1.36) will be removed in Backstage 1.41.0