### PR TITLE
Update create-pullreq-catalog-info.yaml

### DIFF
--- a/chocott-contents/scaffolders/catalog-info/create-pullreq-catalog-info.yaml
+++ b/chocott-contents/scaffolders/catalog-info/create-pullreq-catalog-info.yaml
@@ -75,7 +75,6 @@ spec:
       name: Publish2GitHub
       action: publish:github:pull-request
       input:
-        allowedHosts: ['github.com']
         title: adding catalog-info.yaml
         description: pull it from default template
         repoUrl: ${{ parameters.repoUrl }}


### PR DESCRIPTION
remove allowedHost from publish:github steps