### PR TITLE
Workaround for node-fetch Premature close error

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-trixie-slim AS base
+FROM node:24.16-trixie-slim AS base
 
 # Set up a virtual environment for mkdocs-techdocs-core.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
Pin nodejs to 24.16
see https://github.com/backstage/backstage/issues/34651