### PR TITLE
remove pin of nodejs

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24.16-trixie-slim AS base
+FROM node:24-trixie-slim AS base
 
 # Set up a virtual environment for mkdocs-techdocs-core.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
24.18.0 was released.
This release was fixed node-fetch premature close error.

see #611